### PR TITLE
Sticky Footer

### DIFF
--- a/source/assets/stylesheets/base/_base.scss
+++ b/source/assets/stylesheets/base/_base.scss
@@ -29,4 +29,9 @@
 
 body {
   background-color: $background-gray;
+  display: flex;
+  flex-direction: column;
+}
+body, html {
+  height: 100%;
 }

--- a/source/assets/stylesheets/partials/_layout.scss
+++ b/source/assets/stylesheets/partials/_layout.scss
@@ -1,5 +1,6 @@
 #content-wrapper {
   padding-top: 68px;
+  flex: 1 0 auto;
 
   @include media ($phone-landscape) {
     padding-top: 54px;


### PR DESCRIPTION
The body seems to be just a little larger than the screen even when there is no overflow, or at least on my chrome dev tools. Not sure what to do about it. 