### PR TITLE
Update redirects

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -1,0 +1,55 @@
+# Internal
+
+# https://www.euroteamoutreach.org/abouteto
+- original: abouteto
+  new: /about
+
+# https://www.euroteamoutreach.org/blogs
+- original: blogs
+  new: /blog
+
+# https://www.euroteamoutreach.org/donations
+- original: donations
+  new: /donate
+
+# External
+
+# https://www.euroteamoutreach.org/cmo
+- original: cmo
+  new: https://www.cmoproject.org/
+
+# https://www.euroteamoutreach.org/cmomovie
+- original: cmomovie
+  new: https://www.cmoproject.org/movie/
+
+# https://www.euroteamoutreach.org/cmotrailer
+- original: cmotrailer
+  new: https://www.cmoproject.org/movie-trailer/
+
+# https://www.euroteamoutreach.org/bftv
+- original: bftv
+  new: https://getbiblefirst.com/
+
+# https://www.euroteamoutreach.org/biblefirst
+- original: biblefirst
+  new: https://getbiblefirst.com/
+
+# https://www.euroteamoutreach.org/cbc
+- original: cbc
+  new: https://getbiblefirst.com/
+
+# https://www.euroteamoutreach.org/biblefirstcourses
+- original: biblefirstcourses
+  new: https://getbiblefirst.com/
+
+# https://www.euroteamoutreach.org/good-and-evil
+- original: good-and-evil
+  new: http://goodandevilbook.com/
+
+# https://www.euroteamoutreach.org/pictures
+- original: pictures
+  new: https://www.facebook.com/pg/euroteamoutreach/photos/
+
+# https://www.euroteamoutreach.org/subscribe
+- original: subscribe
+  new: https://euroteamoutreach.us6.list-manage.com/subscribe/post?u=672df31cd6d0e7132c9c4c7d1&amp;id=d107e57061

--- a/environments/production.rb
+++ b/environments/production.rb
@@ -18,6 +18,10 @@ activate :s3_sync do |s3|
   s3.error_document = "404.html"
 end
 
+data.redirects.each do |redirect|
+  redirect "#{redirect.original}/index.html", to: redirect.new
+end
+
 # https://github.com/fredjean/middleman-s3_sync#http-caching
 default_caching_policy max_age: (60 * 60 * 24 * 365)
 caching_policy "text/html", public: true, max_age: 0, must_revalidate: true

--- a/source/redirects/bf-downloads.html.haml
+++ b/source/redirects/bf-downloads.html.haml
@@ -1,4 +1,0 @@
----
-hide_from_sitemap: true
----
-

--- a/source/redirects/bf-faq.html.haml
+++ b/source/redirects/bf-faq.html.haml
@@ -1,4 +1,0 @@
----
-hide_from_sitemap: true
----
-

--- a/source/redirects/bf-lesson-overview.html.haml
+++ b/source/redirects/bf-lesson-overview.html.haml
@@ -1,4 +1,0 @@
----
-hide_from_sitemap: true
----
-

--- a/source/redirects/bf-purchase.html.haml
+++ b/source/redirects/bf-purchase.html.haml
@@ -1,4 +1,0 @@
----
-hide_from_sitemap: true
----
-

--- a/source/redirects/bftv.html.haml
+++ b/source/redirects/bftv.html.haml
@@ -1,4 +1,0 @@
----
-hide_from_sitemap: true
----
-

--- a/source/redirects/biblefirst.html.haml
+++ b/source/redirects/biblefirst.html.haml
@@ -1,4 +1,0 @@
----
-hide_from_sitemap: true
----
-

--- a/source/redirects/cmo.html.haml
+++ b/source/redirects/cmo.html.haml
@@ -1,4 +1,0 @@
----
-hide_from_sitemap: true
----
-

--- a/source/redirects/cmo/movie/index.html.haml
+++ b/source/redirects/cmo/movie/index.html.haml
@@ -1,3 +1,0 @@
----
-hide_from_sitemap: true
----

--- a/source/redirects/cmo/trailer/index.html.haml
+++ b/source/redirects/cmo/trailer/index.html.haml
@@ -1,3 +1,0 @@
----
-hide_from_sitemap: true
----

--- a/source/redirects/cmomovie.html.haml
+++ b/source/redirects/cmomovie.html.haml
@@ -1,4 +1,0 @@
----
-hide_from_sitemap: true
----
-

--- a/source/redirects/cmotrailer.html.haml
+++ b/source/redirects/cmotrailer.html.haml
@@ -1,4 +1,0 @@
----
-hide_from_sitemap: true
----
-

--- a/source/redirects/good-and-evil.html.haml
+++ b/source/redirects/good-and-evil.html.haml
@@ -1,4 +1,0 @@
----
-hide_from_sitemap: true
----
-

--- a/source/redirects/jesus.html.haml
+++ b/source/redirects/jesus.html.haml
@@ -1,4 +1,0 @@
----
-hide_from_sitemap: true
----
-

--- a/source/redirects/pictures.html.haml
+++ b/source/redirects/pictures.html.haml
@@ -1,4 +1,0 @@
----
-hide_from_sitemap: true
----
-

--- a/source/redirects/subscribe.html.haml
+++ b/source/redirects/subscribe.html.haml
@@ -1,4 +1,0 @@
----
-hide_from_sitemap: true
----
-

--- a/source/redirects/teamjesus.html.haml
+++ b/source/redirects/teamjesus.html.haml
@@ -1,4 +1,0 @@
----
-hide_from_sitemap: true
----
-


### PR DESCRIPTION
This PR updates several of our existing redirects to use native Middleman syntax instead of relying on S3 configs. This has both advantages and drawbacks.

- S3 redirects create proper 301 redirects which are more SEO friendly.
- The config for S3 redirects bets blanked out on every deploy. 🙄 Therefor it must be reapplied manually, which is easy to forget.
- MM redirects create permanent files in the bucket which guarantee that the redirect will always happen.
- As best I can tell, MM redirects will only work with simple path names, such as `/cmo`. Complex paths, such as `/index.php?=cmo` do not work.
- Complex paths like the one mentioned above used to redirect fine using S3 configs. But at this point, I can't get them to work. I think this may have something to do with HTTPS redirects. Not sure.

Bottom line: for now, we're switching to MM redirects because the provide the solution needed for critical redirects such as the cmo movie. In future, it would be good to find a more permanent solution that uses proper 301's.